### PR TITLE
Widen `serial_test` version range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ documentation = "https://docs.rs/reference-counted-singleton"
 
 [dev-dependencies]
 assert_matches = { version = "1.5" }
-serial_test    = { version = "0.9" }
+serial_test    = { version = ">0.9,<3" }


### PR DESCRIPTION
Fedora already ships `serial_test` 2.x, and
`reference-counted-singleton` builds fine with that version.

Widen the accepted range from 0.9 to 2.x to reflect this