### PR TITLE
Exclude unnecessary files from the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ categories = [
 ]
 repository = "https://github.com/koutheir/reference-counted-singleton"
 documentation = "https://docs.rs/reference-counted-singleton"
+exclude = [".gitignore", "coverage*"]
 
 [dependencies]
 


### PR DESCRIPTION
`.gitignore` and the coverage files are not needed by dependent crates

```
michel in reference-counted-singleton on  exclude-unnecessary-files is 📦 v0.1.2 via 🐍 v3.11.6 (.venv311) via 🦀 v1.73.0
⬢ [fedora-toolbox:38] ❯ cargo package --allow-dirty --no-verify
    Updating crates.io index
   Packaging reference-counted-singleton v0.1.2 (/home/michel/src/github/koutheir/reference-counted-singleton)
    Packaged 7 files, 13.7KiB (4.1KiB compressed)

michel in reference-counted-singleton on  exclude-unnecessary-files is 📦 v0.1.2 via 🐍 v3.11.6 (.venv311) via 🦀 v1.73.0
⬢ [fedora-toolbox:38] ❯ tar tf target/package/reference-counted-singleton-0.1.2.crate
reference-counted-singleton-0.1.2/CHANGELOG.md
reference-counted-singleton-0.1.2/Cargo.toml
reference-counted-singleton-0.1.2/Cargo.toml.orig
reference-counted-singleton-0.1.2/LICENSE.txt
reference-counted-singleton-0.1.2/README.md
reference-counted-singleton-0.1.2/src/lib.rs
reference-counted-singleton-0.1.2/src/tests.rs
```